### PR TITLE
SOL-217 Deprecate Liquidation Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ to Proposals and Voting.
 This bot monitors all borrow events of COMP to see if the borrower address has accrued enough COMP
 to pass significant governance thresholds. This can be an early indication of governance attacks.
 
-### [Liquidation Monitor](liquidation-monitor/README.md)
+### [DEPRECATED: Liquidation Monitor](liquidation-monitor/README.md)
 
-This bot detects when an account on Compound is able to be liquidated.
+This bot detects when an account on Compound is able to be liquidated. Since deprecation of the Compound v2 monitoring API, this bot has been deprecated.
 
 ### [Low Liquidity Market Attack Monitor](low-liquidity-market-attack-monitor/README.md)
 

--- a/liquidation-monitor/README.md
+++ b/liquidation-monitor/README.md
@@ -1,8 +1,10 @@
-# Compound Liquidation Monitor
+# DEPRECATED: Compound Liquidation Monitor
 
 ## Description
 
-This bot detects when an account on Compound is able to be liquidated.
+This bot detects when an account on Compound is able to be liquidated. 
+
+Note: Since the deprecation of the Compound v2 monitoring API, this bot has been deprecated as well. The line, ` "start:prod": "forta-agent run --prod",` has been removed from package.json to prevent accidental deployment.
 
 ## Optimizations
 

--- a/liquidation-monitor/README.md
+++ b/liquidation-monitor/README.md
@@ -4,7 +4,7 @@
 
 This bot detects when an account on Compound is able to be liquidated.
 
-Note: Since the deprecation of the Compound v2 monitoring API, this bot has been deprecated as well. The line, `"start:prod": "forta-agent run --prod",` has been removed from package.json to prevent accidental deployment.
+Note: Since the deprecation of the Compound v2 monitoring API, this bot has been deprecated as well.
 
 ## Optimizations
 

--- a/liquidation-monitor/package.json
+++ b/liquidation-monitor/package.json
@@ -7,7 +7,6 @@
   ],
   "scripts": {
     "start": "npm run start:dev",
-    "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",
     "range": "forta-agent run --range",

--- a/liquidation-monitor/package.json
+++ b/liquidation-monitor/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "start": "npm run start:dev",
+    "start:prod": "forta-agent run --prod",
     "tx": "forta-agent run --tx",
     "block": "forta-agent run --block",
     "range": "forta-agent run --range",


### PR DESCRIPTION
-Since we're simply deprecating the monitor, I've added a DEPRECATION label in both READMEs, leaving the code in case we want to review it for future use.
- Also removed the run-in-prod command in the package.json to prevent accidental deployment

Q: If it's better to simply delete the whole thing, please let me know!